### PR TITLE
shell_fish: escape spaces

### DIFF
--- a/shell_fish.go
+++ b/shell_fish.go
@@ -55,6 +55,8 @@ func (f fish) Escape(str string) string {
 			escaped(`\n`)
 		case char == CR:
 			escaped(`\r`)
+		case char == SPACE:
+			backslash(char)
 		case char <= US:
 			hex(char)
 		case char <= AMPERSTAND:


### PR DESCRIPTION
Spaces need to be backslash-escaped in values. Without this, fish treats any var with spaces as an array. Which _looks_ OK when you use the var directly in fish, but ends up as a `:`-separated string for child processes. i.e:

	$ cat > .envrc
	export FOO="1 2 3"
	direnv: error .envrc is blocked. Run `direnv allow` to approve its content.
	
	$ direnv allow
	direnv: loading .envrc
	direnv: export +FOO
	
	# looks good:
	$ echo $FOO
	1 2 3
	
	# uh-oh...
	$ env | grep "FOO"
	FOO=1:2:3