### PR TITLE
ignore BASH_FUNC_* variables

### DIFF
--- a/env_diff.go
+++ b/env_diff.go
@@ -114,6 +114,9 @@ func IgnoredEnv(key string) bool {
 	if strings.HasPrefix(key, "__fish") {
 		return true
 	}
+	if strings.HasPrefix(key, "BASH_FUNC_") {
+		return true
+	}
 	_, found := IGNORED_KEYS[key]
 	return found
 }


### PR DESCRIPTION
The following .envrc:

    direnv_load env VAR=new bash -l -c "direnv dump"

When loaded from a shell that _isn't_ bash (e.g `fish`), gives me:

    /usr/bin/bash: line 167: export: `BASH_FUNC_scl()=() {  local CMD=$1;
     if [ "$CMD" = "load" -o "$CMD" = "unload" ]; then
     eval "module $@";
     else
     /usr/bin/scl "$@";
     fi
    }': not a valid identifier
    /usr/bin/bash: line 167: export: `BASH_FUNC_module()=() {  eval `/usr/bin/modulecmd bash $*`
    }': not a valid identifier

This is because bash exports some whacky variables (for inheriting functions) when it's run as a login shell (these functions come from somewhere in /etc/profile.d). But `direnv apply_dump` generates invalid bash syntax when it hits these variable names. Since it's impossible to export variables with these names in bash, and no other shell is going to care about them, it seems safe to ignore them.