### PR TITLE
shell_fish: use single quotes to simplify escaping logic

### DIFF
--- a/shell_fish.go
+++ b/shell_fish.go
@@ -18,16 +18,13 @@ end
 }
 
 func (f fish) Escape(str string) string {
-	if str == "" {
-		return "''"
-	}
 	in := []byte(str)
-	out := ""
+	out := "'"
 	i := 0
 	l := len(in)
 
 	hex := func(char byte) {
-		out += fmt.Sprintf("\\x%02x", char)
+		out += fmt.Sprintf("'\\x%02x'", char)
 	}
 
 	backslash := func(char byte) {
@@ -35,11 +32,7 @@ func (f fish) Escape(str string) string {
 	}
 
 	escaped := func(str string) {
-		out += str
-	}
-
-	quoted := func(char byte) {
-		out += string([]byte{char})
+		out += "'" + str + "'"
 	}
 
 	literal := func(char byte) {
@@ -57,32 +50,12 @@ func (f fish) Escape(str string) string {
 			escaped(`\r`)
 		case char <= US:
 			hex(char)
-		case char <= AMPERSTAND:
-			quoted(char)
 		case char == SINGLE_QUOTE:
 			backslash(char)
-		case char <= PLUS:
-			quoted(char)
-		case char <= NINE:
-			literal(char)
-		case char <= QUESTION:
-			quoted(char)
-		case char <= LOWERCASE_Z:
-			literal(char)
-		case char == OPEN_BRACKET:
-			quoted(char)
 		case char == BACKSLASH:
 			backslash(char)
-		case char <= CLOSE_BRACKET:
-			quoted(char)
-		case char == UNDERSCORE:
-			literal(char)
-		case char <= BACKTICK:
-			quoted(char)
-		case char <= LOWERCASE_Z:
-			literal(char)
 		case char <= TILDA:
-			quoted(char)
+			literal(char)
 		case char == DEL:
 			hex(char)
 		default:
@@ -90,6 +63,8 @@ func (f fish) Escape(str string) string {
 		}
 		i += 1
 	}
+
+	out += "'"
 
 	return out
 }

--- a/test/direnv-test.fish
+++ b/test/direnv-test.fish
@@ -1,0 +1,53 @@
+#!/usr/bin/env fish
+function eq --argument-names a b
+	if not test (count $argv) = 2
+		echo "Error: " (count $argv) " arguments passed to `eq`: $argv"
+		exit 1
+	end
+		
+	if not test $a = $b
+		printf "Error:\n - expected: %s\n -      got: %s\n" "$a" "$b"
+		exit 1
+	end
+end
+
+cd (dirname (status -f))
+set TEST_DIR $PWD
+set -gx PATH (dirname $TEST_DIR) $PATH
+
+# Reset the direnv loading if any
+set -x DIRENV_CONFIG $PWD
+set -e DIRENV_BASH
+set -e DIRENV_DIR
+set -e DIRENV_MTIME
+set -e DIRENV_DIFF
+
+function direnv_eval
+  #direnv export fish # for debugging
+  eval (direnv export fish)
+end
+
+function test_start -a name
+  cd "$TEST_DIR/scenarios/$name"
+  direnv allow
+  echo "## Testing $name ##"
+  pwd
+end
+
+function test_stop
+  cd $TEST_DIR
+  direnv_eval
+end
+
+### RUN ###
+
+direnv allow
+direnv_eval
+
+test_start dump
+	set -ex LS_COLORS
+	direnv_eval
+	eq "$LS_COLORS" "*.ogg=38;5;45:*.wav=38;5;45"
+	eq "$LESSOPEN" "||/usr/bin/lesspipe.sh %s"
+	eq "$THREE_BACKSLASHES" "\\\\\\"
+test_stop

--- a/test/direnv-test.sh
+++ b/test/direnv-test.sh
@@ -87,6 +87,13 @@ test_start "special-vars"
   unset DIRENV_CONFIG
 test_stop
 
+test_start "dump"
+  direnv_eval
+  test "$LS_COLORS" = "*.ogg=38;5;45:*.wav=38;5;45"
+  test "$THREE_BACKSLASHES" = '\\\'
+  test "$LESSOPEN" = "||/usr/bin/lesspipe.sh %s"
+test_stop
+
 test_start "empty-var"
   direnv_eval
   test "${FOO-unset}" != "unset"

--- a/test/scenarios/dump/.envrc
+++ b/test/scenarios/dump/.envrc
@@ -1,0 +1,6 @@
+direnv_load env \
+	LS_COLORS='*.ogg=38;5;45:*.wav=38;5;45' \
+	LESSOPEN='||/usr/bin/lesspipe.sh %s' \
+	THREE_BACKSLASHES='\\\' \
+	bash -l -c "direnv dump"
+


### PR DESCRIPTION
After I submitted #156 I found that other characters are incorrectly escaped for `fish` too - specifically the '*' character.

Rather than explicitly escaping special characters, this patch just wraps exported values in single quotes, only breaking out for special non-printable characters (\t, \xxx, etc). This makes the logic much simpler, and it now works properly when variables contain spaces and `*` (and perhaps others that I haven't encountered yet).

There's also a new test case, `dump`, which tests both fish & bash on a bunch of special characters, as well as covering #157 (so it'll fail until that it merged as well).