### PR TITLE
Empty variable as unloading in Vim

### DIFF
--- a/shell_vim.go
+++ b/shell_vim.go
@@ -30,5 +30,5 @@ func (x vim) Export(key, value string) string {
 }
 
 func (x vim) Unset(key string) string {
-	return "unlet $" + x.EscapeKey(key) + "\n"
+	return "let $" + x.EscapeKey(key) + " = ''\n"
 }


### PR DESCRIPTION
`unlet $FOO` throws `E488: Trailing characters` error and there
is no way to unload environment variable in Vim
(see http://permalink.gmane.org/gmane.editors.vim.devel/44555).
Instead, just make it empty string (which is not the desired
effect but is the best possible solution)

Related to zimbatm/direnv.vim#2.