### PR TITLE
Direnv should not fail if ../.envrc doesn't exist

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -131,10 +131,13 @@ const STDLIB = "# These are the commands available in an .envrc context\n" +
 	"    rcfile=\"$rcfile/.envrc\"\n" +
 	"    rcpath=\"$rcpath/.envrc\"\n" +
 	"  fi\n" +
-	"  log_status \"loading $rcfile\"\n" +
 	"  pushd \"$(pwd -P 2>/dev/null)\" > /dev/null\n" +
 	"    pushd \"$(dirname \"$rcpath\")\" > /dev/null\n" +
-	"    . \"./$(basename \"$rcpath\")\"\n" +
+	"    if [ -f \"./$(basename \"$rcpath\")\" ]\n" +
+	"    then\n" +
+	"      log_status \"loading $rcfile\"\n" +
+	"      . \"./$(basename \"$rcpath\")\"\n" +
+	"    fi\n" +
 	"    popd > /dev/null\n" +
 	"  popd > /dev/null\n" +
 	"}\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -137,6 +137,8 @@ const STDLIB = "# These are the commands available in an .envrc context\n" +
 	"    then\n" +
 	"      log_status \"loading $rcfile\"\n" +
 	"      . \"./$(basename \"$rcpath\")\"\n" +
+	"    else\n" +
+	"      log_status \"referenced $rcfile does not exist\"\n" +
 	"    fi\n" +
 	"    popd > /dev/null\n" +
 	"  popd > /dev/null\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -129,10 +129,13 @@ source_env() {
     rcfile="$rcfile/.envrc"
     rcpath="$rcpath/.envrc"
   fi
-  log_status "loading $rcfile"
   pushd "$(pwd -P 2>/dev/null)" > /dev/null
     pushd "$(dirname "$rcpath")" > /dev/null
-    . "./$(basename "$rcpath")"
+    if [ -f "./$(basename "$rcpath")" ]
+    then
+      log_status "loading $rcfile"
+      . "./$(basename "$rcpath")"
+    fi
     popd > /dev/null
   popd > /dev/null
 }

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -135,6 +135,8 @@ source_env() {
     then
       log_status "loading $rcfile"
       . "./$(basename "$rcpath")"
+    else
+      log_status "referenced $rcfile does not exist"
     fi
     popd > /dev/null
   popd > /dev/null

--- a/test/direnv-test.sh
+++ b/test/direnv-test.sh
@@ -107,6 +107,10 @@ test_start "empty-var-unset"
   unset FOO
 test_stop
 
+test_start "missing-file-source-env"
+  direnv_eval
+test_stop
+
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
 # BUG: foo/bar is resolved in the .envrc execution context and so can't find
 #      the .envrc file.

--- a/test/scenarios/missing-file-source-env/.envrc
+++ b/test/scenarios/missing-file-source-env/.envrc
@@ -1,0 +1,1 @@
+source_env "$(mktemp -d -t $RANDOM)"


### PR DESCRIPTION
`source_env ..` fails if `../.envrc` doesn't exist. I'm not convinced it should. What are your thoughts on this?

TL;DR

My use-case is a top-level dir which contains multiple apps, each with their specific `.envrc`. I store common values in the top-level dir which is not version-controlled. This global `.envrc` might not exist on all workstations. Currently, direnv fails:

```
/bin/bash: line 134: ./.envrc: No such file or directory
direnv: error exit status 1
```

I would much rather it gracefully handled the absence of `../.envrc`